### PR TITLE
open browser only for "npm start"

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lint": "eslint -f node_modules/eslint-friendly-formatter --ext .js,.jsx,.es .",
     "#build": "we use React as a template engine only (not in client side) so we enable DEV mode everywhere to get awesome dev messages and errors",
     "build": "babel-node scripts/build",
-    "start": "npm run build",
+    "start": "npm run build -- --open",
     "tape": "babel-tape-runner 'scripts/**/__tests__/*'",
     "test": "npm run lint && npm run tape && npm run build -- --production",
     "deploy": "GH_OWNER=putaindecode GH_PROJECT_NAME=putaindecode.fr ./scripts/deploy-to-gh-pages.sh -v"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,6 +29,7 @@ import pkg from "../package"
 import logger from "./utils/logger"
 
 const production = process.argv.indexOf("--production") !== -1
+const open = process.argv.indexOf("--open") !== -1
 
 const mdToHtmlReplacement = [/\.md$/, ".html"]
 
@@ -162,7 +163,9 @@ function build(error, contributors) {
       .build((err) => {
         if (err) {throw err}
 
-        opn("http://localhost:4242")
+        if (open) {
+          opn("http://localhost:4242")
+        }
       })
   }
 }


### PR DESCRIPTION
Now we can use `--open` as argument for the build, npm start use it.
Nice when you work on the build process (`npm run build` don’t open the
browser all the time).