### PR TITLE
Changed the way text was diplayed above pictures

### DIFF
--- a/src/css/blocks/post.css
+++ b/src/css/blocks/post.css
@@ -41,6 +41,11 @@
       padding: 0 1rem;
     }
 
+    .putainde-Post-header--custom .putainde-Title {
+      box-shadow: 0 0px 40px 42px rgba(0,0,0,0.25);
+      background: rgba(0,0,0,0.25);
+    }
+
     .putainde-Title {
       margin: calc(var(--r-lineHeight) / 2) 0;
       overflow: auto;
@@ -85,6 +90,10 @@
           0 0 3px color(#fff a(-90%)),
           0 0 2px color(#fff a(-95%))
         ;
+      }
+
+      .putainde-Post-header--custom .putainde-Title {
+        text-shadow: none;
       }
 
       .putainde-Post-header-picture {

--- a/src/layouts/Post/index.jsx
+++ b/src/layouts/Post/index.jsx
@@ -146,8 +146,8 @@ export default class Post extends DefaultTemplate {
                     file.header && file.header.filter,
                   "putainde-Post-header--dark":
                     file.header && !file.header.light,
-                    "putainde-Post-header--light":
-                      file.header && file.header.light,
+                  "putainde-Post-header--light":
+                    file.header && file.header.light,
                 })}
               >
                 {


### PR DESCRIPTION
Changed a bit the way article titles were displayed when in front of header pictures in articles.
I basically got rid of the text-shadow and added a transparent box-shadow/background which looks nicer when the picture is still loading (imo) and won't mess with font-rendering. 

![before](http://i.imgur.com/YwOkiRo.png)
Before

![after](http://i.imgur.com/FDBSm2n.png)
After

![after with image](http://i.imgur.com/B5pj4ui.png)
After (with image displayed behind)
