### PR TITLE
Fix: Makefiles

### DIFF
--- a/content/posts/shell/apprendre-les-makefiles/index.md
+++ b/content/posts/shell/apprendre-les-makefiles/index.md
@@ -125,7 +125,7 @@ _Markdown_ en _HTML_ :
 
 ``` make
 article.html: article.md
-	marked article.html > article.md
+	marked article.md > article.html
 ```
 
 Cette règle spécifie simplement que pour construire le fichier `article.html`


### PR DESCRIPTION
Fix: Makefiles

Dans son exemple, @madx parle bien de compiler un fichier markdown en html, je pense donc qu'il y a une inversion des fichiers dans l'exemple