### PR TITLE
Replace "top contributors" by "top of most recent contributors"

### DIFF
--- a/web_modules/TopContributors/index.js
+++ b/web_modules/TopContributors/index.js
@@ -13,12 +13,14 @@ export default class TopContributors extends Component {
     const i18n = metadata.i18n
     const contributors = metadata.contributors
     const httpRepository = metadata.pkg.repository.replace(/\.git$/, "")
-
-    let topContributors = Object.keys(contributors.map)
-    topContributors.sort(
-      (a, b) => contributors.contributions[b] - contributors.contributions[a]
+    const recentContributors = Object.keys(contributors.recentContributions)
+    recentContributors.sort(
+      (a, b) => (
+        contributors.recentContributions[b]
+        - contributors.recentContributions[a]
+      )
     )
-    topContributors = topContributors.slice(0, 12)
+    const topContributors = recentContributors.slice(0, 8)
 
     return (
       <div>
@@ -26,6 +28,9 @@ export default class TopContributors extends Component {
           <h2 className="putainde-Title-text">
             { i18n.topContributors }
           </h2>
+          <small style={ { opacity: .5 } }>
+            { i18n.topContributorsNote }
+          </small>
         </div>
 
         <div className="r-Grid r-Grid--withGutter">
@@ -46,7 +51,7 @@ export default class TopContributors extends Component {
                   <Author
                     author={author}
                     afterName={
-                      `(${contributors.contributions[author]} commits)`
+                      `(${contributors.recentContributions[author]} commits)`
                     }
                   />
                 </div>

--- a/web_modules/i18n/index.yml
+++ b/web_modules/i18n/index.yml
@@ -7,6 +7,7 @@
   manifesto: "Putain de code, c'est quoi ?"
   topContributors: "Top des contributeurs"
   topContributorsNoData: "Aucune donnée pour afficher le top des contributeurs"
+  topContributorsNote: "sur les 12 derniers mois"
   initialCommit: "commit initial par"
   morePosts: "Plus d'articles"
   writtenBy: "Écrit par"


### PR DESCRIPTION
(on the last 12 months)

Should close #485 or at least start to improve things :)

Curernt preview

![screen shot 2015-11-06 at 08 12 43](https://cloud.githubusercontent.com/assets/157534/10991523/3fc899d0-845e-11e5-9f3a-07115ed5493a.png)

For now it's a simple and stupid ordering by number of commits.
Since a commit can be a typo or a fucking entire post, we should take that into account.
I was thinking about something like this:

- a comment in an issue on this repo: 1 point
- a commit in the repo: 10 points
- a review: 20 points
- a post: 100 points.

Discuss !